### PR TITLE
新增获取用户的简易订阅和投稿信息接口

### DIFF
--- a/bilibili_api/data/api.json
+++ b/bilibili_api/data/api.json
@@ -554,7 +554,7 @@
                 },
                 "comment": "获取用户粉丝列表（不是自己只能访问前5页，是自己也不能获取全部的样子）"
             },
-            "navnum": {
+            "overview": {
                 "url": "https://api.bilibili.com/x/space/navnum",
                 "method": "GET",
                 "verify": false,

--- a/bilibili_api/data/api.json
+++ b/bilibili_api/data/api.json
@@ -553,6 +553,17 @@
                     "order": "desc倒序,asc正序"
                 },
                 "comment": "获取用户粉丝列表（不是自己只能访问前5页，是自己也不能获取全部的样子）"
+            },
+            "navnum": {
+                "url": "https://api.bilibili.com/x/space/navnum",
+                "method": "GET",
+                "verify": false,
+                "params": {
+                    "mid": "uid",
+                    "jsonp": "jsonp",
+                    "callback": "__jp8"
+                },
+                "comment": "获取用户的简易订阅和投稿信息(主要是这些的数量统计)"
             }
         },
         "operate": {

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -603,22 +603,21 @@ def get_followers(uid: int, order: str = "desc", limit: int = 114514, callback=N
     return followings[:limit]
 
 
-def get_navnum(uid: int, verify: utils.Verify = None):
+def get_overview(uid: int, verify: utils.Verify = None):
     """
     获取用户的简易订阅和投稿信息
     :param uid:
     :param verify:
     :return:
     """
-    api = API["user"]["info"]["navnum"]
+    api = API["user"]["info"]["overview"]
     params = {
         "mid": uid,
         "jsonp": "jsonp",
         "callback": "__jp8"  #必须带有这个默认的参数
     }
-    data = utils.get(url=api["url"], params=params, verify=verify, data_type='text')
-    json_data = json.loads(data[6:-1])['data']  # 转为json格式处理最后返回data
-    return json_data
+    data = utils.get(url=api["url"], params=params, verify=verify)
+    return data
 
 
 # 操作用户

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -603,6 +603,24 @@ def get_followers(uid: int, order: str = "desc", limit: int = 114514, callback=N
     return followings[:limit]
 
 
+def get_navnum(uid: int, verify: utils.Verify = None):
+    """
+    获取用户的简易订阅和投稿信息
+    :param uid:
+    :param verify:
+    :return:
+    """
+    api = API["user"]["info"]["navnum"]
+    params = {
+        "mid": uid,
+        "jsonp": "jsonp",
+        "callback": "__jp8"  #必须带有这个默认的参数
+    }
+    data = utils.get(url=api["url"], params=params, verify=verify, data_type='text')
+    json_data = json.loads(data[6:-1])['data']  # 转为json格式处理最后返回data
+    return json_data
+
+
 # 操作用户
 
 

--- a/bilibili_api/utils.py
+++ b/bilibili_api/utils.py
@@ -336,7 +336,7 @@ class CrackUid(object):
 # 请求相关
 
 
-def request(method: str, url: str, params=None, data=None, cookies=None, headers=None, **kwargs):
+def request(method: str, url: str, params=None, data_type: str = 'json',data=None, cookies=None, headers=None, **kwargs):
     st = {
         "url": url,
         "params": params,
@@ -354,28 +354,31 @@ def request(method: str, url: str, params=None, data=None, cookies=None, headers
         content = req.content.decode("utf8")
         if req.headers.get("content-length") == 0:
             return None
-        con = json.loads(content)
-        if con["code"] != 0:
-            if "message" in con:
-                msg = con["message"]
-            elif "msg" in con:
-                msg = con["msg"]
-            else:
-                msg = "请求失败，服务器未返回失败原因"
-            raise exceptions.BilibiliException(con["code"], msg)
+        if data_type=='text':
+            return content
         else:
-            if 'data' in con.keys():
-                return con['data']
-            else:
-                if 'result' in con.keys():
-                    return con["result"]
+            con = json.loads(content)
+            if con["code"] != 0:
+                if "message" in con:
+                    msg = con["message"]
+                elif "msg" in con:
+                    msg = con["msg"]
                 else:
-                    return None
+                    msg = "请求失败，服务器未返回失败原因"
+                raise exceptions.BilibiliException(con["code"], msg)
+            else:
+                if 'data' in con.keys():
+                    return con['data']
+                else:
+                    if 'result' in con.keys():
+                        return con["result"]
+                    else:
+                        return None
     else:
         raise exceptions.NetworkException(req.status_code)
 
 
-def get(url, params=None, cookies=None, headers=None, **kwargs):
+def get(url, params=None, cookies=None, headers=None, data_type: str = 'json',**kwargs):
     """
     专用GET请求
     :param url:
@@ -385,11 +388,11 @@ def get(url, params=None, cookies=None, headers=None, **kwargs):
     :param kwargs:
     :return:
     """
-    resp = request("GET", url=url, params=params, cookies=cookies, headers=headers, **kwargs)
+    resp = request("GET", url=url, params=params, cookies=cookies, headers=headers, data_type= data_type,**kwargs)
     return resp
 
 
-def post(url, cookies, data=None, headers=None, **kwargs):
+def post(url, cookies, data=None, headers=None,data_type: str = 'json', **kwargs):
     """
     专用POST请求
     :param url:
@@ -399,7 +402,7 @@ def post(url, cookies, data=None, headers=None, **kwargs):
     :param kwargs:
     :return:
     """
-    resp = request("POST", url=url, data=data, cookies=cookies, headers=headers, **kwargs)
+    resp = request("POST", url=url, data=data, cookies=cookies, headers=headers,data_type= data_type, **kwargs)
     return resp
 
 


### PR DESCRIPTION
1. 新增获取用户的简易订阅和投稿信息接口，接口地址：在api.json中的user中的info中的navnum，url为https://api.bilibili.com/x/space/navnum?mid=xxx&&jsonp=jsonp&callback=__jp8,xxx为用户的id，函数是user中的get_navnum，返回该用户的
        video:视频投稿量
        bangumi:追番量
        cinema:追剧量(包括电影电视剧等)
        tag:关注标签（频道）数
        article:专栏（文章）投稿量
        album:相簿（图片）投稿量等
2. 因为返回的内容不一定能用json加载，所以在utils.py在request、get、post方法中新增一个参数daa_type,表示返回的数据类型，默认json，可以传入为text，返回网页内容的字符串，增强程序的扩展性。