### PR TITLE
新增获取房间直播流列表接口

### DIFF
--- a/bilibili_api/data/api.json
+++ b/bilibili_api/data/api.json
@@ -845,6 +845,19 @@
                     "page": "页码"
                 },
                 "comment": "获取房间黑名单列表，登录账号需要是该房间房管"
+            },
+            "room_play_url": {
+                "url": "https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl",
+                "method": "GET",
+                "verify": false,
+                "params": {
+                    "cid": "真实房间号",
+                    "platform": "web",
+                    "qn": "清晰度编号，原画10000，超清250，高清150",
+                    "https_url_req": "1",
+                    "ptype": "16"
+                },
+                "comment": "获取房间直播流列表"
             }
         },
         "operate": {


### PR DESCRIPTION
接口地址示例：https://api.live.bilibili.com/xlive/web-room/v1/playUrl/playUrl?cid=5440&qn=10000&platform=web&https_url_req=1&ptype=16
cid：真实房间号
platform：平台类型，默认为web
qn：（可选）清晰度编号，原画10000（建议），超清250，高清150
https_url_req：（可选）请求https地址，默认为1，改成0似乎也没有变化
ptype：（可选）含义不明，可能是platform type？默认为16