### PR TITLE
修复live.connect_all_LiveDanmaku只会连接一个房间的问题

### DIFF
--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -342,13 +342,7 @@ def connect_all_LiveDanmaku(*livedanmaku_classes):
         task = room.connect(True)
         tasks.append(task)
 
-    async def run():
-        for task in tasks:
-            await task
-
-    asyncio.get_event_loop().run_until_complete(run())
-    asyncio.get_event_loop().run_forever()
-
+    asyncio.get_event_loop().run_until_complete(asyncio.wait(tasks))
 
 class LiveDanmaku(object):
     """


### PR DESCRIPTION
`await task` 导致永远不会轮到下一个房间